### PR TITLE
Exclude db/migrate/**/*

### DIFF
--- a/templates/.rubocop.yml
+++ b/templates/.rubocop.yml
@@ -16,6 +16,7 @@ AllCops:
   DisabledByDefault: true
   Exclude:
     - db/schema.rb
+    - db/migrate/**/*
     - node_modules/**/*
     - vendor/**/*
   TargetRubyVersion: <%= RUBY_VERSION.split(".")[0..-2].join(".") %>


### PR DESCRIPTION
Migrations are often generated, so checking them is less productive.